### PR TITLE
Fix link to docker-compose.yml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Note:
 ### docker compose
 First check that Docker compose is already [installed](https://docs.docker.com/compose/install/) on your host.
 
-1. Copy the [docker-compose.yaml](https://github.com/jojo141185/mopidy-docker/blob/main/docker/docker-compose.yaml) file from this repository to the current directory.
+1. Copy the [docker-compose.yml](https://github.com/jojo141185/mopidy-docker/blob/main/docker/docker-compose.yml) file from this repository to the current directory.
 2. Make sure that your mopidy config file (mopidy.conf) is placed in a subfolder named "config".  
 You can also add / modify the volume paths in the yaml file, i.e. to your local media folder or the directory where the metadata information will be stored on host (see table above).
 3. Start the mopidy container with the following command  


### PR DESCRIPTION
This is a mistake I also often make, and it was perhaps even the cause of this one! I named my file `compose.yaml` (c61773517b3764513ddcf58f4b8e735d1f0c8427) and only later renamed it to `docker-compose.yml`, (4183511a3143f40f149948d0c0f193510f363520), with the extension being changed sneakily 😉.